### PR TITLE
BACKEND-1138: Allocate a slot additionally based on JobVertex's ResourceProfile

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -300,7 +300,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 			'}';
 	}
 
-	static ResourceProfile fromResourceSpec(ResourceSpec resourceSpec, int networkMemory) {
+	static public ResourceProfile fromResourceSpec(ResourceSpec resourceSpec, int networkMemory) {
 		Map<String, Resource> copiedExtendedResources = new HashMap<>(resourceSpec.getExtendedResources());
 
 		return new ResourceProfile(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -515,7 +515,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 							toSchedule,
 							queued,
 							new SlotProfile(
-								ResourceProfile.fromResourceSpec(vertex.getJobVertex().getJobVertex().getPreferredResources(), 0),
+								ResourceProfile.fromResourceSpec(vertex.getJobVertex().getJobVertex().getMinResources(), 0),
 								preferredLocations,
 								previousAllocationIDs,
 								allPreviousExecutionGraphAllocationIds),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -515,7 +515,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 							toSchedule,
 							queued,
 							new SlotProfile(
-								ResourceProfile.UNKNOWN,
+								ResourceProfile.fromResourceSpec(vertex.getJobVertex().getJobVertex().getPreferredResources(), 0),
 								preferredLocations,
 								previousAllocationIDs,
 								allPreviousExecutionGraphAllocationIds),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.instance;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -66,5 +67,11 @@ public class SimpleSlotContext implements SlotContext {
 	@Override
 	public TaskManagerGateway getTaskManagerGateway() {
 		return taskManagerGateway;
+	}
+
+	@Override
+	public ResourceProfile getResourceProfile()
+	{
+		return ResourceProfile.ANY;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 
 /**
@@ -35,4 +36,6 @@ public interface SlotContext extends SlotInfo {
 	 * @return The gateway that can be used to send messages to the TaskManager.
 	 */
 	TaskManagerGateway getTaskManagerGateway();
+
+	ResourceProfile getResourceProfile();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
@@ -37,5 +37,10 @@ public interface SlotContext extends SlotInfo {
 	 */
 	TaskManagerGateway getTaskManagerGateway();
 
+	/**
+	 * Gets the resource profile of the underlying allocated slot
+	 *
+	 * @return The resource profile that can be used to define if the slot has the requested resources
+	 */
 	ResourceProfile getResourceProfile();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -188,8 +188,13 @@ public class SlotSharingManager {
 			slotProfile,
 			() -> resolvedRootSlotsValues.stream().flatMap(Collection::stream),
 			(MultiTaskSlot multiTaskSlot) -> multiTaskSlot.getSlotContextFuture().join(),
-			(MultiTaskSlot multiTaskSlot) -> !multiTaskSlot.contains(groupId),
-			MultiTaskSlotLocality::of);
+			(MultiTaskSlot multiTaskSlot) ->
+				!multiTaskSlot.contains(groupId) && multiTaskSlot.getSlotContextFuture()
+																 .join()
+																 .getResourceProfile()
+																 .isMatching(slotProfile.getResourceProfile()),
+			MultiTaskSlotLocality::of
+		);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -162,7 +162,7 @@ public class SchedulerTestBase extends TestLogger {
 				final SlotOffer slotOffer = new SlotOffer(
 					new AllocationID(),
 					i,
-					ResourceProfile.UNKNOWN);
+					ResourceProfile.ANY);
 
 				slotOffers.add(slotOffer);
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
@@ -318,6 +319,12 @@ public class SingleLogicalSlotTest extends TestLogger {
 		@Override
 		public TaskManagerGateway getTaskManagerGateway() {
 			return taskManagerGateway;
+		}
+
+		@Override
+		public ResourceProfile getResourceProfile()
+		{
+			return ResourceProfile.ANY;
 		}
 	}
 }


### PR DESCRIPTION
Currently no information (ResourceProfile.UNKNOWN) about needed resources is provided for a slot pool and resource manager.
Pass jobVertex's ResourceProfile to 
- SlotPool - for comparing already allocated slot resources with needed
- ResourceManager - for allocating needed resources